### PR TITLE
Convert pvs/maven-demo to GitHub Actions

### DIFF
--- a/.github/workflows/maven-demo.yml
+++ b/.github/workflows/maven-demo.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v4.0.0
     - name: sh
       shell: bash
       run: mvn -B -DskipTests clean package
@@ -15,12 +15,12 @@ jobs:
     needs: Build
     steps:
     - name: checkout
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v4.0.0
     - name: sh
       shell: bash
       run: mvn test
     - name: Publish test results
-      uses: EnricoMi/publish-unit-test-result-action@v2.8.0
+      uses: EnricoMi/publish-unit-test-result-action@v2.9.0
       if: always()
       with:
         junit_files: target/surefire-reports/*.xml
@@ -29,7 +29,7 @@ jobs:
     needs: Test
     steps:
     - name: checkout
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v4.0.0
     - name: sh
       shell: bash
       run: chmod +x -R ${{ github.workspace }}/scripts/deliver.sh


### PR DESCRIPTION
Pipeline migrated from [Jenkins](http://13.127.6.236:8080/job/pvs/job/maven-demo/) :tada:

## Manual steps

Perform the following steps to complete the migration:

### pvs/maven-demo
- [ ] Ensure build tool is available: `maven`